### PR TITLE
Fix crash in demo

### DIFF
--- a/maploc/data/image.py
+++ b/maploc/data/image.py
@@ -69,11 +69,11 @@ def resize_image(
     if fn is not None:
         assert isinstance(size, int)
         scale = size / fn(h, w)
-        h_new, w_new = int(round(h * scale)), int(round(w * scale))
+        h_new, w_new = (int(round(x * scale)) for x in (h, w))
         scale = (scale, scale)
     else:
         if isinstance(size, (collections.abc.Sequence, np.ndarray)):
-            w_new, h_new = size
+            w_new, h_new = (int(x) for x in size)
         elif isinstance(size, int):
             w_new = h_new = size
         else:

--- a/maploc/demo.py
+++ b/maploc/demo.py
@@ -170,14 +170,14 @@ class Demo:
                 pitch=-pitch,
             )
         image, _, camera, *maybe_valid = resize_image(
-            image, size.numpy(), camera=camera, valid=valid
+            image, size.tolist(), camera=camera, valid=valid
         )
         valid = None if valid is None else maybe_valid
 
         max_stride = max(self.model.image_encoder.layer_strides)
-        size = (np.ceil((size / max_stride)) * max_stride).int()
+        size = (torch.ceil(size / max_stride) * max_stride).int()
         image, valid, camera = pad_image(
-            image, size.numpy(), camera, crop_and_center=True
+            image, size.tolist(), camera, crop_and_center=True
         )
 
         return dict(


### PR DESCRIPTION
In recent versions of torchvision, resize crashes if the target size is a numpy scalar.